### PR TITLE
Harden exec low level against command injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ DAMN VULNERABLE WEB APPLICATION
 v1.10 (*Not Yet Released)
 ======
 
++ Hardened command execution low level to prevent OS command injection. (Codex)
 + Improved IIS support. (@g0tmi1k)
 + Improved setup system check. (@g0tmi1k)
 

--- a/tests/test_exec_low.py
+++ b/tests/test_exec_low.py
@@ -1,0 +1,25 @@
+import subprocess
+
+
+def run_low(ip: str) -> str:
+    ip = ip.replace("\"", "\\\"")
+    script = (
+        '$html=""; '
+        '$_POST["Submit"]="1"; '
+        '$_REQUEST["ip"]="' + ip + '"; '
+        'include "vulnerabilities/exec/source/low.php"; '
+        'echo $html;'
+    )
+    result = subprocess.run(["php", "-r", script], capture_output=True, text=True)
+    return result.stdout
+
+
+def test_valid_ip():
+    out = run_low("127.0.0.1")
+    assert "PING" in out
+
+
+def test_reject_injection():
+    out = run_low("127.0.0.1; cat /etc/passwd")
+    assert "Invalid input" in out
+    assert "root:" not in out

--- a/vulnerabilities/exec/README.md
+++ b/vulnerabilities/exec/README.md
@@ -1,0 +1,6 @@
+# Command Injection Module
+
+The low-level example has been hardened to prevent OS command injection.
+User-supplied input is validated as an IPv4 address or hostname and
+sanitized before being passed to `/bin/ping`. Shell metacharacters are
+rejected and only standard ping output is returned to the user.

--- a/vulnerabilities/exec/source/low.php
+++ b/vulnerabilities/exec/source/low.php
@@ -1,21 +1,42 @@
 <?php
 
-if( isset( $_POST[ 'Submit' ]  ) ) {
+// Hardened ping functionality to prevent OS command injection.
+if( isset( $_POST[ 'Submit' ] ) ) {
 	// Get input
 	$target = $_REQUEST[ 'ip' ];
 
-	// Determine OS and execute the ping command.
-	if( stristr( php_uname( 's' ), 'Windows NT' ) ) {
-		// Windows
-		$cmd = shell_exec( 'ping  ' . $target );
+	// Block shell metacharacters outright
+	if( preg_match( '/[;|&`$()<>\n\r]/', $target ) ) {
+		$html .= '<pre>Invalid input.</pre>';
+	}
+	// Allow only IPv4 addresses or hostnames (letters, digits, dots, hyphens)
+	elseif( ! ( filter_var( $target, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ||
+		preg_match( '/^[A-Za-z0-9.-]+$/', $target ) ) ) {
+		$html .= '<pre>Invalid input.</pre>';
 	}
 	else {
-		// *nix
-		$cmd = shell_exec( 'ping  -c 4 ' . $target );
-	}
+		// Build safe command using fixed binary and escaped argument
+		$cmd = '/bin/ping -c 3 -W 2 ' . escapeshellarg( $target );
+		$output = shell_exec( $cmd );
 
-	// Feedback for the end user
-	$html .= "<pre>{$cmd}</pre>";
+		if( $output !== null ) {
+			$lines = explode( "\n", $output );
+			$safe  = array();
+
+			// Return only typical ping result lines
+			foreach( $lines as $line ) {
+				if( preg_match( '/^[A-Za-z0-9\s\.:,()=%-]+$/', $line ) ) {
+					$safe[] = $line;
+				}
+			}
+
+			$html .= '<pre>' . implode( "\n", $safe ) . '</pre>';
+		}
+		else {
+			// Do not expose raw shell output on failure
+			$html .= '<pre>Ping failed.</pre>';
+		}
+	}
 }
 
 ?>


### PR DESCRIPTION
## Summary
- validate and sanitize input in Command Injection low level
- run ping using a fixed binary and escape arguments
- document fix and cover it with tests

## Testing
- `php -l vulnerabilities/exec/source/low.php`
- `python3 -m pytest -s tests/test_exec_low.py`
- `python3 -m pytest -s` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_b_68c6a63d3160832a92f517e23426f2fa